### PR TITLE
Handle deleted blocks

### DIFF
--- a/libmpq/mpq-internal.h
+++ b/libmpq/mpq-internal.h
@@ -49,6 +49,7 @@
 
 /* define generic hash values. */
 #define LIBMPQ_HASH_FREE			0xFFFFFFFF	/* hash table entry is empty and has always been empty. */
+#define LIBMPQ_HASH_DELETED			0xFFFFFFFE	/* hash table entry used to point to a block but is now deleted (can be reclaimed). */
 
 /* define special files. */
 #define LIBMPQ_LISTFILE_NAME			"(listfile)"	/* internal listfile. */

--- a/libmpq/mpq.c
+++ b/libmpq/mpq.c
@@ -702,7 +702,8 @@ int32_t libmpq__file_number_from_hash(mpq_archive_s *mpq_archive, uint32_t hash1
 	for (uint32_t i = hash1; mpq_archive->mpq_hash[i].block_table_index != LIBMPQ_HASH_FREE; i = (i + 1) & (ht_count - 1)) {
 
 		/* if the other two hashes match, we found our file number. */
-		if (mpq_archive->mpq_hash[i].hash_a == hash2 &&
+		if (mpq_archive->mpq_hash[i].block_table_index != LIBMPQ_HASH_DELETED &&
+			mpq_archive->mpq_hash[i].hash_a == hash2 &&
 		    mpq_archive->mpq_hash[i].hash_b == hash3) {
 
 			/* return the file number. */


### PR DESCRIPTION
While working on pfile/loadsave refactoring I tried to implement [`MpqWriter::HasFile`](https://github.com/diasurgical/devilutionX/blob/c3b1415662afca5c548ac2297d8ffe98e594f55a/Source/mpq/mpq_writer.cpp#L536) on [`MpqReader`](https://github.com/diasurgical/devilutionX/blob/c3b1415662afca5c548ac2297d8ffe98e594f55a/Source/mpq/mpq_reader.hpp#L19).

Sadly I got sometimes a crash when the file wasn't present.
But the [`MpqWriter::HasFile`](https://github.com/diasurgical/devilutionX/blob/c3b1415662afca5c548ac2297d8ffe98e594f55a/Source/mpq/mpq_writer.cpp#L536) implementation worked.
I checked what was the difference between `libmpq` and the `MpqWriter`.
`MpqWriter` [handles deleted blocks](https://github.com/diasurgical/devilutionX/blob/c3b1415662afca5c548ac2297d8ffe98e594f55a/Source/mpq/mpq_writer.cpp#L317-L318) but `libmpq` didn't.
This pr adds deleted blocks support to `libmpq`.

I'm no mpq expert, so my assumptions could be wrong. 😉 

Side-note (not directly related to this pr):
While checking both implementations I couldn't find [these lines](https://github.com/diasurgical/libmpq/blob/f6592aedd0e0d5fd40006acec8e2eb82faae8da8/libmpq/mpq.c#L715-L718) in [`MpqWriter::GetHashIndex`](https://github.com/diasurgical/devilutionX/blob/c3b1415662afca5c548ac2297d8ffe98e594f55a/Source/mpq/mpq_writer.cpp#L307-L324). I'm unsure if this matters.