### PR TITLE
Reuse the decompression work buffer

### DIFF
--- a/libmpq/common.c
+++ b/libmpq/common.c
@@ -183,7 +183,7 @@ int32_t libmpq__decrypt_key(uint8_t *in_buf, uint32_t in_size, uint32_t block_si
 }
 
 /* function to decompress or explode a block from mpq archive. */
-int32_t libmpq__decompress_block(uint8_t *in_buf, uint32_t in_size, uint8_t *out_buf, uint32_t out_size, uint32_t compression_type) {
+int32_t libmpq__decompress_block(uint8_t *in_buf, uint32_t in_size, uint8_t *work_buf, uint8_t *out_buf, uint32_t out_size, uint32_t compression_type) {
 
 	/* some common variables. */
 	int32_t tb = 0;
@@ -207,9 +207,8 @@ int32_t libmpq__decompress_block(uint8_t *in_buf, uint32_t in_size, uint8_t *out
 
 			/* check if we are using pkzip compression algorithm. */
 			if (compression_type == LIBMPQ_FLAG_COMPRESS_PKZIP) {
-
 				/* decompress using pkzip. */
-				if ((tb = libmpq__decompress_pkzip(in_buf, in_size, out_buf, out_size)) < 0) {
+				if ((tb = libmpq__decompress_pkzip(in_buf, in_size, work_buf, out_buf, out_size)) < 0) {
 
 					/* something on decompression failed. */
 					return tb;
@@ -224,7 +223,7 @@ int32_t libmpq__decompress_block(uint8_t *in_buf, uint32_t in_size, uint8_t *out
 				 *  version 1.0.9 distributed with warcraft 3 passes the full path name of the opened archive
 				 *  as the new last parameter.
 				 */
-				if ((tb = libmpq__decompress_multi(in_buf, in_size, out_buf, out_size)) < 0) {
+				if ((tb = libmpq__decompress_multi(in_buf, in_size, work_buf, out_buf, out_size)) < 0) {
 
 					/* something on decompression failed. */
 					return tb;

--- a/libmpq/common.h
+++ b/libmpq/common.h
@@ -67,6 +67,7 @@ int32_t libmpq__encryption_key_from_filename_v2(
 int32_t libmpq__decompress_block(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
+	uint8_t		*work_buf,
 	uint8_t		*out_buf,
 	uint32_t	out_size,
 	uint32_t	compression_type

--- a/libmpq/extract.h
+++ b/libmpq/extract.h
@@ -21,6 +21,9 @@
 #ifndef _EXTRACT_H
 #define _EXTRACT_H
 
+#include "explode.h"
+#include "huffman.h"
+
 /* define compression types for multilpe compressions. */
 #define LIBMPQ_COMPRESSION_HUFFMAN		0x01		/* huffman compression. (used on wave files only and introduced in starcraft) */
 #define LIBMPQ_COMPRESSION_ZLIB			0x02		/* zlib compression. (introduced in warcraft 3) */
@@ -29,6 +32,8 @@
 #define LIBMPQ_COMPRESSION_WAVE_MONO		0x40		/* adpcm 4:1 compression. (introduced in starcraft) */
 #define LIBMPQ_COMPRESSION_WAVE_STEREO		0x80		/* adpcm 4:1 compression. (introduced in starcraft) */
 
+#define LIBMPQ_DECOMPRESS_WORK_BUF_SIZE	(sizeof(pkzip_cmp_s) > sizeof(struct huffman_tree_s) ? sizeof(pkzip_cmp_s) : sizeof(struct huffman_tree_s))
+
 /*
  *  table for decompression functions, return value for all functions
  *  is the transferred data size or one of the following error constants:
@@ -36,7 +41,7 @@
  *  LIBMPQ_ERROR_MALLOC
  *  LIBMPQ_ERROR_DECOMPRESS
  */
-typedef int32_t		(*DECOMPRESS)(uint8_t *, uint32_t, uint8_t *, uint32_t);
+typedef int32_t		(*DECOMPRESS)(uint8_t *, uint32_t, uint8_t *, uint8_t *, uint32_t);
 typedef struct {
 	uint32_t	mask;			/* decompression bit. */
 	DECOMPRESS	decompress;		/* decompression function. */
@@ -51,6 +56,7 @@ typedef struct {
 extern int32_t libmpq__decompress_huffman(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
+	uint8_t		*work_buf,
 	uint8_t		*out_buf,
 	uint32_t	out_size
 );
@@ -59,6 +65,7 @@ extern int32_t libmpq__decompress_huffman(
 extern int32_t libmpq__decompress_zlib(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
+	uint8_t		*work_buf,
 	uint8_t		*out_buf,
 	uint32_t	out_size
 );
@@ -67,6 +74,7 @@ extern int32_t libmpq__decompress_zlib(
 extern int32_t libmpq__decompress_pkzip(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
+	uint8_t		*work_buf,
 	uint8_t		*out_buf,
 	uint32_t	out_size
 );
@@ -75,6 +83,7 @@ extern int32_t libmpq__decompress_pkzip(
 extern int32_t libmpq__decompress_bzip2(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
+	uint8_t		*work_buf,
 	uint8_t		*out_buf,
 	uint32_t	out_size
 );
@@ -83,6 +92,7 @@ extern int32_t libmpq__decompress_bzip2(
 extern int32_t libmpq__decompress_wave_mono(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
+	uint8_t		*work_buf,
 	uint8_t		*out_buf,
 	uint32_t	out_size
 );
@@ -91,6 +101,7 @@ extern int32_t libmpq__decompress_wave_mono(
 extern int32_t libmpq__decompress_wave_stereo(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
+	uint8_t		*work_buf,
 	uint8_t		*out_buf,
 	uint32_t	out_size
 );
@@ -99,6 +110,7 @@ extern int32_t libmpq__decompress_wave_stereo(
 extern int32_t libmpq__decompress_multi(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
+	uint8_t		*decompress_work_buf,
 	uint8_t		*out_buf,
 	uint32_t	out_size
 );

--- a/libmpq/mpq-internal.h
+++ b/libmpq/mpq-internal.h
@@ -142,6 +142,8 @@ struct mpq_archive {
 	/* non archive structure related members. */
 	mpq_map_s	*mpq_map;		/* map table between valid blocks and hashes. */
 	uint32_t	files;			/* number of files in archive, which could be extracted. */
+
+	uint8_t *decompress_work_buf;
 };
 
 #endif						/* _MPQ_INTERNAL_H */


### PR DESCRIPTION
This introduces a 195 KiB cost to peak memory usage but greatly reduces temporary allocations during decompression.

Before:
![libmpq-before](https://user-images.githubusercontent.com/216339/173821254-0fa0c656-dbc7-4ea6-a5d4-775a27252783.png)

After:
![libmpq-after](https://user-images.githubusercontent.com/216339/173821274-bd4975b5-207c-4900-8617-d747afe62499.png)

