### PR TITLE
Remove unused <fnctl.h> include

### DIFF
--- a/libmpq/mpq.c
+++ b/libmpq/mpq.c
@@ -33,7 +33,6 @@
 
 /* generic includes. */
 #include <errno.h>
-#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
This is a POSIX-specific header and libmpq does not use it.