### PR TITLE
Fix fseeko on NXDK

### DIFF
--- a/libmpq/platform.h
+++ b/libmpq/platform.h
@@ -21,7 +21,9 @@
 #ifndef _PLATFORM_H
 #define _PLATFORM_H
 
-#ifdef _MSC_VER
+#if defined(NXDK)
+  #define fseeok fseek
+#elif defined(_MSC_VER)
   #define fseeko _fseeki64
 #endif
 


### PR DESCRIPTION
`fseeko` is not available on NXDK so we just use `fseek`.