### PR TITLE
Fix null dereference in get_basename()

### DIFF
--- a/libmpq/common.c
+++ b/libmpq/common.c
@@ -101,9 +101,9 @@ int32_t libmpq__decrypt_block(uint32_t *in_buf, uint32_t in_size, uint32_t seed)
 /* returns the last component of a path after / or \ */
 static const char *get_basename(const char *filename) {
 	const char *basename = strrchr(filename, '\\');
-	if (*basename != '\0') return basename + 1;
+	if (basename != NULL) return basename + 1;
 	basename = strrchr(filename, '/');
-	if (*basename != '\0') return basename + 1;
+	if (basename != NULL) return basename + 1;
 	return filename;
 }
 


### PR DESCRIPTION
If the character is not found, rather than pointing to a null character, it seems that `strrchr()` just returns a null pointer instead.