### PR TITLE
Add sized string versions of in-MPQ file functions

### DIFF
--- a/libmpq/common.h
+++ b/libmpq/common.h
@@ -16,14 +16,24 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */       
+ */
 
 #ifndef _COMMON_H
 #define _COMMON_H
 
+#include <stddef.h>
+#include <stdint.h>
+
 /* function to return the hash to a given string. */
 uint32_t libmpq__hash_string(
 	const char	*key,
+	uint32_t	offset
+);
+
+/* function to return the hash to a given string view. */
+uint32_t libmpq__hash_string_s(
+	const char	*key,
+	size_t	key_length,
 	uint32_t	offset
 );
 
@@ -55,9 +65,23 @@ int32_t libmpq__encryption_key_from_filename(
 	uint32_t	*key
 );
 
+int32_t libmpq__encryption_key_from_filename_s(
+	const char	*filename,
+	size_t	filename_length,
+	uint32_t	*key
+);
+
 /* function to obtain the decryption key given a filename for files with LIBMPQ_FLAG_ENCRYPTION_KEY_V2. */
 int32_t libmpq__encryption_key_from_filename_v2(
 	const char	*filename,
+	uint32_t	offset,
+	uint32_t	unpacked_size,
+	uint32_t	*key
+);
+
+int32_t libmpq__encryption_key_from_filename_v2_s(
+	const char	*filename,
+	size_t	filename_length,
 	uint32_t	offset,
 	uint32_t	unpacked_size,
 	uint32_t	*key

--- a/libmpq/mpq.h
+++ b/libmpq/mpq.h
@@ -33,6 +33,7 @@ extern "C" {
 #endif
 
 /* generic includes. */
+#include <stddef.h>
 #include <stdint.h>
 
 #if defined(__GNUC__) && (__GNUC__ >= 4)
@@ -86,16 +87,21 @@ extern LIBMPQ_API int32_t libmpq__file_encrypted(mpq_archive_s *mpq_archive, uin
 extern LIBMPQ_API int32_t libmpq__file_compressed(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *compressed);
 extern LIBMPQ_API int32_t libmpq__file_imploded(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *imploded);
 extern LIBMPQ_API int32_t libmpq__file_number(mpq_archive_s *mpq_archive, const char *filename, uint32_t *number);
+extern LIBMPQ_API int32_t libmpq__file_number_s(mpq_archive_s *mpq_archive, const char *filename, size_t filename_length, uint32_t *number);
 extern LIBMPQ_API void libmpq__file_hash(const char *filename, uint32_t *hash1, uint32_t *hash2, uint32_t *hash3);
+extern LIBMPQ_API void libmpq__file_hash_s(const char *filename, size_t filename_length, uint32_t *hash1, uint32_t *hash2, uint32_t *hash3);
 extern LIBMPQ_API int32_t libmpq__file_number_from_hash(mpq_archive_s *mpq_archive, uint32_t hash1, uint32_t hash2, uint32_t hash3, uint32_t *number);
 extern LIBMPQ_API int32_t libmpq__file_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);
 extern LIBMPQ_API int32_t libmpq__file_read_with_filename(mpq_archive_s *mpq_archive, uint32_t file_number, const char *filename, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);
+extern LIBMPQ_API int32_t libmpq__file_read_with_filename_s(mpq_archive_s *mpq_archive, uint32_t file_number, const char *filename, size_t filename_length, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);
 extern LIBMPQ_API int32_t libmpq__file_read_with_temporary_buffer(mpq_archive_s *mpq_archive, uint32_t file_number, uint8_t *out_buf, libmpq__off_t out_size, uint8_t *tmp_buf, libmpq__off_t tmp_size, libmpq__off_t *transferred);
 extern LIBMPQ_API int32_t libmpq__file_read_with_filename_and_temporary_buffer(mpq_archive_s *mpq_archive, uint32_t file_number, const char *filename, uint8_t *out_buf, libmpq__off_t out_size, uint8_t *tmp_buf, libmpq__off_t tmp_size, libmpq__off_t *transferred);
+extern LIBMPQ_API int32_t libmpq__file_read_with_filename_and_temporary_buffer_s(mpq_archive_s *mpq_archive, uint32_t file_number, const char *filename, size_t filename_length, uint8_t *out_buf, libmpq__off_t out_size, uint8_t *tmp_buf, libmpq__off_t tmp_size, libmpq__off_t *transferred);
 
 /* generic block processing functions. */
 extern LIBMPQ_API int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_number);
 extern LIBMPQ_API int32_t libmpq__block_open_offset_with_filename(mpq_archive_s *mpq_archive, uint32_t file_number, const char *filename);
+extern LIBMPQ_API int32_t libmpq__block_open_offset_with_filename_s(mpq_archive_s *mpq_archive, uint32_t file_number, const char *filename, size_t filename_length);
 extern LIBMPQ_API int32_t libmpq__block_close_offset(mpq_archive_s *mpq_archive, uint32_t file_number);
 extern LIBMPQ_API int32_t libmpq__block_size_unpacked(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, libmpq__off_t *unpacked_size);
 extern LIBMPQ_API int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);


### PR DESCRIPTION
Allows efficient interop with C++ `std::string_view`.

/cc @ephphatha @StephenCWills 