### PR TITLE
Expose more APIs

### DIFF
--- a/libmpq/common.c
+++ b/libmpq/common.c
@@ -29,6 +29,7 @@
 
 /* libmpq generic includes. */
 #include "extract.h"
+#include "endian.h"
 
 #include "common.h"
 
@@ -74,7 +75,7 @@ int32_t libmpq__encrypt_block(uint32_t *in_buf, uint32_t in_size, uint32_t seed)
 		ch        = *in_buf ^ (seed + seed2);
 		seed      = ((~seed << 0x15) + 0x11111111) | (seed >> 0x0B);
 		seed2     = *in_buf + seed2 + (seed2 << 5) + 3;
-		*in_buf++ = ch;
+		*in_buf++ = libmpq__bswap_LE32(ch);
 	}
 
 	/* if no error was found, return decrypted bytes. */
@@ -92,7 +93,7 @@ int32_t libmpq__decrypt_block(uint32_t *in_buf, uint32_t in_size, uint32_t seed)
 	/* we're processing the data 4 bytes at a time. */
 	for (; in_size >= 4; in_size -= 4) {
 		seed2    += crypt_buf[0x400 + (seed & 0xFF)];
-		ch        = *in_buf ^ (seed + seed2);
+		ch        = libmpq__bswap_LE32(*in_buf) ^ (seed + seed2);
 		seed      = ((~seed << 0x15) + 0x11111111) | (seed >> 0x0B);
 		seed2     = ch + seed2 + (seed2 << 5) + 3;
 		*in_buf++ = ch;

--- a/libmpq/common.h
+++ b/libmpq/common.h
@@ -24,33 +24,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* function to return the hash to a given string. */
-uint32_t libmpq__hash_string(
-	const char	*key,
-	uint32_t	offset
-);
-
-/* function to return the hash to a given string view. */
-uint32_t libmpq__hash_string_s(
-	const char	*key,
-	size_t	key_length,
-	uint32_t	offset
-);
-
-/* function to encrypt a block. */
-int32_t libmpq__encrypt_block(
-	uint32_t	*in_buf,
-	uint32_t	in_size,
-	uint32_t	seed
-);
-
-/* function to decrypt a block. */
-int32_t libmpq__decrypt_block(
-	uint32_t	*in_buf,
-	uint32_t	in_size,
-	uint32_t	seed
-);
-
 /* function to detect decryption key. */
 int32_t libmpq__decrypt_key(
 	uint8_t		*in_buf,

--- a/libmpq/mpq.h
+++ b/libmpq/mpq.h
@@ -56,6 +56,12 @@ extern "C" {
 #define LIBMPQ_ERROR_DECRYPT			-11		/* we don't know the decryption seed. */
 #define LIBMPQ_ERROR_UNPACK			-12		/* error on unpacking file. */
 
+/* Precalculated value of libmpq__hash_string("(block table)", 0x300) */
+#define LIBMPQ_BLOCK_TABLE_HASH_KEY 3968054179u
+
+/* Precalculated value of libmpq__hash_string("(hash table)", 0x300) */
+#define LIBMPQ_HASH_TABLE_HASH_KEY 3283040112u
+
 /* internal data structure. */
 typedef struct mpq_archive mpq_archive_s;
 
@@ -106,6 +112,12 @@ extern LIBMPQ_API int32_t libmpq__block_close_offset(mpq_archive_s *mpq_archive,
 extern LIBMPQ_API int32_t libmpq__block_size_unpacked(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, libmpq__off_t *unpacked_size);
 extern LIBMPQ_API int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);
 extern LIBMPQ_API int32_t libmpq__block_read_with_temporary_buffer(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, uint8_t *out_buf, libmpq__off_t out_size, uint8_t *tmp_buf, libmpq__off_t tmp_size, libmpq__off_t *transferred);
+
+/* generic mpq functions */
+extern LIBMPQ_API uint32_t libmpq__hash_string(const char *key, uint32_t offset);
+extern LIBMPQ_API uint32_t libmpq__hash_string_s(const char *key, size_t key_length, uint32_t offset);
+extern LIBMPQ_API int32_t libmpq__encrypt_block(uint32_t *in_buf, uint32_t in_size, uint32_t seed);
+extern LIBMPQ_API int32_t libmpq__decrypt_block(uint32_t *in_buf, uint32_t in_size, uint32_t seed);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. Expose some APIs that can be used in DevilutionX's MPQ writer.
2. Move byte-swapping into decrypt/encrypt.