### PR TITLE
Remove use of locale-dependent `toupper`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ Makefile.in
 /missing
 /py-compile
 /stamp-h1
+/confdefs.h
+/configure~
+/config.h.in~
+/configure.ac~

--- a/configure.ac
+++ b/configure.ac
@@ -1,20 +1,20 @@
 # the autoconf initilization.
-AC_INIT(libmpq, 0.4.2, [mbroemme@libmpq.org], [libmpq])
+AC_INIT([libmpq],[0.4.2],[mbroemme@libmpq.org],[libmpq])
 AC_SUBST(LIBMPQ_ABI, [1:0:0])
 
 # detect the canonical host and target build environment.
-AC_CANONICAL_SYSTEM
+AC_CANONICAL_TARGET
 
 # initialize autoconf and automake system.
 AM_INIT_AUTOMAKE([no-dependencies])
 AC_CONFIG_HEADERS([config.h:config.h.in])
 
 # notices.
-AC_PREREQ(2.53)
+AC_PREREQ([2.71])
 AC_REVISION($Revision: 1.6 $)
 
 # checking for programs.
-AC_PROG_LIBTOOL
+LT_INIT
 AC_PROG_MAKE_SET
 AC_PROG_CC
 AC_SYS_LARGEFILE
@@ -57,11 +57,11 @@ AC_CHECK_HEADER([bzlib.h], [], [AC_MSG_ERROR([*** bzlib.h is required, install b
 AC_CHECK_LIB([bz2], [BZ2_bzDecompressInit], [], [AC_MSG_ERROR([*** BZ2_bzDecompressInit is required, install bzip2 library files])])
 
 # When we're running gcc 4 or greater, compile with -fvisibility=hidden.
-AC_TRY_COMPILE([
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #if !defined(__GNUC__) || (__GNUC__ < 4)
 #error not gcc4
 #endif
-], [], [CFLAGS="$CFLAGS -fvisibility=hidden"])
+]], [[]])],[CFLAGS="$CFLAGS -fvisibility=hidden"],[])
 
 # find python for binding
 AM_PATH_PYTHON([2.4],,[:])
@@ -72,7 +72,7 @@ AC_CONFIG_FILES([libmpq.pc])
 AC_CONFIG_FILES([libmpq-config],[chmod +x libmpq-config])
 
 # creating files.
-AC_OUTPUT([
+AC_CONFIG_FILES([
 Makefile
 libmpq/Makefile
 bindings/Makefile
@@ -83,3 +83,4 @@ doc/man1/Makefile
 doc/man3/Makefile
 tools/Makefile
 ])
+AC_OUTPUT

--- a/libmpq/common.c
+++ b/libmpq/common.c
@@ -19,7 +19,6 @@
  */
 
 /* generic includes. */
-#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -38,6 +37,10 @@
  */
 #include "crypt_buf.h"
 
+static unsigned char ascii_toupper(unsigned char c) {
+	return (c >= 'a' && c <= 'z') ? c - ('a' - 'A') : c;
+}
+
 /* function to return the hash to a given string. */
 uint32_t libmpq__hash_string_s(const char *key, size_t key_length, uint32_t offset) {
 
@@ -50,7 +53,7 @@ uint32_t libmpq__hash_string_s(const char *key, size_t key_length, uint32_t offs
 
 	/* prepare seeds. */
 	for (size_t i = 0; i < key_length; ++i) {
-		ch    = toupper(*key++);
+		ch    = ascii_toupper(*key++);
 		seed1 = crypt_buf[offset + ch] ^ (seed1 + seed2);
 		seed2 = ch + seed1 + seed2 + (seed2 << 5) + 3;
 	}


### PR DESCRIPTION
Use an ASCII-only implementation instead.